### PR TITLE
fix mixedcontent

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Android on GitHub</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
+        <link href="//fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
         <style>
             body {
                 font-family: "Roboto", sans-serif;


### PR DESCRIPTION
`//` or `https://`?

`https://` pros:
- succesfully loads when `index.html` fetched from disk (via `file://`).
